### PR TITLE
refactor: implement validation logic

### DIFF
--- a/proto/router/mint.proto
+++ b/proto/router/mint.proto
@@ -18,6 +18,6 @@ message Mint {
   string source_domain_sender = 2;
   uint64 nonce = 3;
   cosmos.base.v1beta1.Coin amount = 4;
-  string destination_domain = 5;
+  uint32 destination_domain = 5;
   string mint_recipient = 6;
 }

--- a/x/router/keeper/handle_message.go
+++ b/x/router/keeper/handle_message.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"strconv"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -57,7 +56,7 @@ func (k Keeper) HandleMessage(ctx sdk.Context, msg []byte) error {
 			return sdkerrors.Wrapf(types.ErrHandleMessage, "unable to find local token denom for this burn")
 		}
 
-		addr, err := sdk.Bech32ifyAddressBytes("noble", burnMessage.MintRecipient[12:])
+		addr, err := sdk.Bech32ifyAddressBytes(sdk.GetConfig().GetBech32AccountAddrPrefix(), burnMessage.MintRecipient[12:])
 		if err != nil {
 			return sdkerrors.Wrapf(types.ErrHandleMessage, "error bech32 encoding mint recipient address")
 		}
@@ -71,7 +70,7 @@ func (k Keeper) HandleMessage(ctx sdk.Context, msg []byte) error {
 				Denom:  tokenPair.LocalToken,
 				Amount: sdk.NewIntFromBigInt(burnMessage.Amount.BigInt()),
 			},
-			DestinationDomain: strconv.Itoa(int(outerMessage.DestinationDomain)),
+			DestinationDomain: outerMessage.DestinationDomain,
 			MintRecipient:     addr,
 		}
 		k.SetMint(ctx, mint)

--- a/x/router/keeper/util.go
+++ b/x/router/keeper/util.go
@@ -56,7 +56,11 @@ const (
 func DecodeIBCForward(msg []byte) (types.IBCForwardMetadata, error) {
 	var res types.IBCForwardMetadata
 	if err := proto.Unmarshal(msg, &res); err != nil {
-		return types.IBCForwardMetadata{}, sdkerrors.Wrapf(types.ErrDecodingIBCForward, "error decoding ibc forward")
+		return types.IBCForwardMetadata{}, sdkerrors.Wrap(types.ErrDecodingIBCForward, err.Error())
+	}
+
+	if err := res.Validate(); err != nil {
+		return types.IBCForwardMetadata{}, sdkerrors.Wrap(types.ErrDecodingIBCForward, err.Error())
 	}
 
 	return res, nil

--- a/x/router/types/errors.go
+++ b/x/router/types/errors.go
@@ -8,8 +8,11 @@ import (
 
 // x/router module sentinel errors
 var (
-	ErrHandleMessage       = sdkerrors.Register(ModuleName, 2, "err during handle message")
-	ErrDecodingMessage     = sdkerrors.Register(ModuleName, 3, "err decoding message")
-	ErrDecodingBurnMessage = sdkerrors.Register(ModuleName, 4, "err decoding burn message")
-	ErrDecodingIBCForward  = sdkerrors.Register(ModuleName, 5, "err decoding ibc forward")
+	ErrHandleMessage               = sdkerrors.Register(ModuleName, 2, "err during handle message")
+	ErrDecodingMessage             = sdkerrors.Register(ModuleName, 3, "err decoding message")
+	ErrDecodingBurnMessage         = sdkerrors.Register(ModuleName, 4, "err decoding burn message")
+	ErrDecodingIBCForward          = sdkerrors.Register(ModuleName, 5, "err decoding ibc forward")
+	ErrInvalidMint                 = sdkerrors.Register(ModuleName, 6, "validation failed due to malformed Mint")
+	ErrInvalidInFlightPacket       = sdkerrors.Register(ModuleName, 7, "validation failed due to malformed InFlightPacket")
+	ErrInvalidStoreForwardMetadata = sdkerrors.Register(ModuleName, 8, "validation failed due to malformed StoreIBCForwardMetadata")
 )

--- a/x/router/types/genesis.go
+++ b/x/router/types/genesis.go
@@ -26,6 +26,11 @@ func (gs GenesisState) Validate() error {
 			return fmt.Errorf("duplicated index for InFlightPackets")
 		}
 		inFlightPacketsIndexMap[index] = struct{}{}
+
+		// Validate the element to ensure semantic correctness
+		if err := elem.Validate(); err != nil {
+			return err
+		}
 	}
 
 	// Check for duplicated index in mints
@@ -36,6 +41,11 @@ func (gs GenesisState) Validate() error {
 			return fmt.Errorf("duplicated index for Mints")
 		}
 		mintsIndexMap[index] = struct{}{}
+
+		// Validate the element to ensure semantic correctness
+		if err := elem.Validate(); err != nil {
+			return err
+		}
 	}
 
 	// Check for duplicated index in ibcForwards
@@ -46,6 +56,11 @@ func (gs GenesisState) Validate() error {
 			return fmt.Errorf("duplicated index for IBCForwards")
 		}
 		ibcForwardsIndexMap[index] = struct{}{}
+
+		// Validate the element to ensure semantic correctness
+		if err := elem.Validate(); err != nil {
+			return err
+		}
 	}
 
 	return gs.Params.Validate()

--- a/x/router/types/validate.go
+++ b/x/router/types/validate.go
@@ -1,0 +1,82 @@
+package types
+
+import (
+	"fmt"
+
+	"github.com/circlefin/noble-cctp-router-private/x/cctp/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	host "github.com/cosmos/ibc-go/v3/modules/core/24-host"
+)
+
+// Validate ensures that the fields are populated with data that is semantically correct.
+func (m *Mint) Validate() error {
+	if m.SourceDomainSender == "" {
+		return sdkerrors.Wrap(ErrInvalidMint, "the source domain sender cannot be an empty string")
+	}
+
+	if m.DestinationDomain != types.NobleDomainId {
+		return sdkerrors.Wrapf(ErrInvalidMint, "received an invalid destination domain, expected(%d) got(%d)", types.NobleDomainId, m.DestinationDomain)
+	}
+
+	if _, err := sdk.AccAddressFromBech32(m.MintRecipient); err != nil {
+		return sdkerrors.Wrapf(ErrInvalidMint, "mint recipient %s is not a valid Noble address", m.MintRecipient)
+	}
+
+	if m.Amount == nil {
+		return sdkerrors.Wrap(ErrInvalidMint, "amount cannot be nil")
+	}
+
+	if err := m.Amount.Validate(); err != nil {
+		return sdkerrors.Wrapf(ErrInvalidMint, "amount validation error occurred %s", err)
+	}
+
+	return nil
+}
+
+// Validate ensures that the fields are populated with data that is semantically correct.
+func (i *InFlightPacket) Validate() error {
+	if i.SourceDomainSender == "" {
+		return sdkerrors.Wrap(ErrInvalidInFlightPacket, "the source domain sender cannot be an empty string")
+	}
+
+	if err := host.ChannelIdentifierValidator(i.Channel); err != nil {
+		return sdkerrors.Wrapf(ErrInvalidInFlightPacket, "invalid channel identifier: %s", err)
+	}
+
+	if err := host.PortIdentifierValidator(i.Port); err != nil {
+		return sdkerrors.Wrapf(ErrInvalidInFlightPacket, "invalid port identifier: %s", err)
+	}
+
+	return nil
+}
+
+// Validate ensures that the fields are populated with data that is semantically correct.
+func (i *StoreIBCForwardMetadata) Validate() error {
+	if i.SourceDomainSender == "" {
+		return sdkerrors.Wrap(ErrInvalidStoreForwardMetadata, "the source domain sender cannot be an empty string")
+	}
+
+	if err := i.Metadata.Validate(); err != nil {
+		return sdkerrors.Wrap(ErrInvalidStoreForwardMetadata, err.Error())
+	}
+
+	return nil
+}
+
+// Validate ensures that the fields are populated with data that is semantically correct.
+func (i *IBCForwardMetadata) Validate() error {
+	if i.DestinationReceiver == "" {
+		return fmt.Errorf("the destination receiver cannot be an empty string")
+	}
+
+	if err := host.ChannelIdentifierValidator(i.Channel); err != nil {
+		return fmt.Errorf("invalid channel identifier in IBC forward metadata: %w", err)
+	}
+
+	if err := host.PortIdentifierValidator(i.Port); err != nil {
+		return fmt.Errorf("invalid port identifier in IBC forward metadata: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR changes the `destination_domain` on `Mint` from a string to an uint32, which conforms to the CCTP spec. This allows us to avoid unnecessary type casting.

Additionally we have implemented `Validate` methods on the various types being used so that we can properly validate the genesis contents and messages 